### PR TITLE
Provide iterable interface with iterate method

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,6 +4,8 @@
     "transform-es2015-modules-commonjs",
     "transform-es2015-arrow-functions",
     "transform-es2015-block-scoping",
+    "transform-es2015-computed-properties",
+    "transform-es2015-shorthand-properties",
     "check-es2015-constants"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -77,6 +77,21 @@ Lill.each(owner, iterate, optionalContext);
 
 Be warned that you should **not modify the list** during iterator invocation as it may cause unexpected behavior. This comes from nature of linked list structure as any changes in the chain of items could break iteration.
 
+#### Iterable interface
+
+LiLL supports iterating over items using the [Iterable interface](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#iterable). You can use higher order functions (eg. [wu.js](https://fitzgen.github.io/wu.js/)) to achieve much fine grained control while maintaining speed of iteration. However be warned that without native support for iterators there might be increased number of objects to be collected by garbage collector.
+
+```js
+const things = wu(Lill.iterate(owner))
+	.pluck('prop')
+	.map(createThing);
+
+for (const thing of things) {
+	// do your work with the thing
+}
+const thingsArray = Array.from(things);
+```
+
 ### Finding item in the list ###
 
 If you are looking for a particular item, using each means that it will iterate over every item. Using `find` quits the loop once the predicate function returns `true`. If no predicate is fulfilled, the `null` is returned.

--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
   },
   "main": "lib/lill.js",
   "scripts": {
-    "pretest": "npm run compile",
     "test": "mocha",
     "build": "node bin/build.js",
-    "compile": "babel -qd lib src"
+    "compile": "babel -qd lib src",
+    "prepublish": "npm run compile"
   },
   "devDependencies": {
     "babel-cli": "^6.3.17",
@@ -34,7 +34,9 @@
     "babel-plugin-check-es2015-constants": "^6.3.13",
     "babel-plugin-transform-es2015-arrow-functions": "^6.3.13",
     "babel-plugin-transform-es2015-block-scoping": "^6.3.13",
+    "babel-plugin-transform-es2015-computed-properties": "^6.3.13",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.3.16",
+    "babel-plugin-transform-es2015-shorthand-properties": "^6.3.13",
     "babel-plugin-transform-runtime": "^6.3.13",
     "babel-register": "^6.3.13",
     "babel-runtime": "^6.3.19",

--- a/src/lill.js
+++ b/src/lill.js
@@ -207,6 +207,24 @@ export function find(owner, predicate, ctx) {
   return null;
 };
 
+export function iterate(owner) {
+  const data = validateAttached(owner);
+
+  let item = data.head;
+  const next = () => {
+    if (!item) {
+      return { done: true };
+    }
+    const result = { done: false, value: item };
+    item = item[data.bNext];
+    return result;
+  }
+
+  return {[Symbol.iterator]() {
+    return { next }
+  }};
+}
+
 export function isAttached(owner) {
   return owner != null && owner[bData] != null;
 }

--- a/test/lill.test.js
+++ b/test/lill.test.js
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 chai.use(sinonChai);
 
-import Lill from '../lib/lill';
+import Lill from '../src/lill';
 
 describe('Lill', function() {
 
@@ -469,12 +469,48 @@ describe('Lill', function() {
     });
 
     it('optionally accepts third argument being context for the predicate function', function() {
-      var ctx, spy;
+      const spy = sinon.spy();
+      const ctx = {};
       this.add(this.firstItem);
-      spy = sinon.spy();
-      Lill.find(this.owner, spy, ctx = {});
+      Lill.find(this.owner, spy, ctx);
       expect(spy).to.be.calledOn(ctx);
     });
+  });
+
+  it('should respond to iterate method', function() {
+    expect(Lill).to.respondTo('iterate');
+  });
+
+  describe('iterate()', function() {
+
+    it('expects attached object in first argument', function() {
+      expectAttached('iterate');
+    });
+
+    it('returns iterable object', function() {
+      const iterable = Lill.iterate(this.owner);
+      expect(iterable).to.be.an('object');
+      expect(iterable[Symbol.iterator]).to.be.an('function');
+    });
+
+    it('iterates over linked items', function() {
+      const expectIterable = (items) => {
+        const actual = Array.from(Lill.iterate(this.owner));
+        expect(actual).to.eql(items);
+      }
+
+      expectIterable([]);
+
+      this.add(this.firstItem);
+      expectIterable([this.firstItem]);
+
+      this.add(this.secondItem);
+      expectIterable([this.firstItem, this.secondItem]);
+
+      this.remove(this.firstItem);
+      expectIterable([this.secondItem]);
+    });
+
   });
 
   it('should respond to getSize method', function() {


### PR DESCRIPTION
Also included small change in executing tests against source files so actual compilation step to file can be omitted and to be able run tests in watch mode using `npm test -- --watch`.

Closes #5 